### PR TITLE
fix: change WRS New badge color for contrast

### DIFF
--- a/src/app/provider/[lavaid]/_components/ProviderOptimzerMetricsChart.tsx
+++ b/src/app/provider/[lavaid]/_components/ProviderOptimzerMetricsChart.tsx
@@ -473,7 +473,7 @@ export function ProviderOptimizerMetricsChart({ providerId }: { providerId: stri
                     onClick={() => setMetricMode('wrs')}
                   >
                     WRS
-                    <span className="absolute -top-2 -right-1.5 text-[9px] font-semibold text-red-500">New</span>
+                    <span className="absolute -top-2 -right-1.5 text-[9px] font-semibold text-emerald-400">New</span>
                   </button>
                   <button
                     className={cn(


### PR DESCRIPTION
## Summary
- Changes the "New" badge on the WRS toggle from `text-red-500` to `text-emerald-400` so it's visible against the red primary button background

## Test plan
- [ ] Verify the green "New" badge is visible on both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)